### PR TITLE
Add members to CNCF wg-storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,46 @@ See this [google doc](https://docs.google.com/document/d/1JMNVNP-ZHz8cGlnqckOnpJ
 
 ## Members
 
-* Ben Hindman (@benh) [chair]
-* Steven Tan (@stevenphtan)
-* Clinton Kitson (@clintonskitson)
-* Alex Chircop (@chira001)
-* Steve Wong (@cantbewong)
-* Venkat Ramakrishnan (@katkrish)
-* Gou Rao (@gourao)
-* Vinod Jayaraman (@jvinod)
-* Allen Samuels (@allensamuels)
-* Yaron Haviv (@yaronhaviv)
-* Rakesh Jain (@rakeshjn)
+* Cloud Foundry
+  * Julian Hjortshoj ([@julian-hj](https://github.com/julian-hj))
+  * Paul Warren ([@paulcwarren](https://github.com/paulcwarren))
+* Dell EMC
+  * Clinton Kitson ([@clintonskitson](https://github.com/clintonskitson))
+  * Steve Wong ([@cantbewong](https://github.com/cantbewong))
+* Diamanti
+  * Chakravarthy Nelluri ([@chakri-nelluri](https://github.com/chakri-nelluri))
+* Docker
+  * Brian Goff ([@cpuguy83](https://github.com/cpuguy83))
+  * Julien Quintard ([@mycure](https://github.com/mycure))
+  * Mike Goelzer ([@mgoelzer](https://github.com/mgoelzer))
+* Google
+  * Saad Ali ([@saad-ali](https://github.com/saad-ali))
+  * Michael Rubin ([@matchstick](https://github.com/matchstick))
+  * Tim Hockin ([@thockin](https://github.com/thockin))
+* Huawei
+  * Steven Tan ([@stevenphtan](https://github.com/stevenphtan))
+* IBM
+  * Rakesh Jain ([@rakeshjn](https://github.com/rakeshjn))
+* iguazio
+  * Yaron Haviv ([@yaronhaviv](https://github.com/yaronha))
+* Mesosphere
+  * Ben Hindman ([@benh](https://github.com/benh)) **[chair]**
+  * James DeFelice ([@jdef](https://github.com/jdef))
+  * Jie Yu ([@jieyu](https://github.com/jieyu))
+* Portworx
+  * Venkat Ramakrishnan ([@katkrish](https://twitter.com/katkrish?lang=en))
+  * Gou Rao ([@gourao](https://github.com/gourao))
+  * Vinod Jayaraman ([@jvinod](https://github.com/jvinod))
+* Red Hat
+  * Steve Watt ([@wattsteve](https://github.com/wattsteve))
+* StorageOS
+  * Alex Chircop ([@chira001](https://github.com/chira001))
+* Western Digital (SanDisk)
+  * Allen Samuels ([@allensamuels](https://github.com/allensamuels))
+  
+## Mailing List
+
+https://groups.google.com/forum/#!forum/container-storage-interface-working-group
 
 ## Meeting Minutes
 


### PR DESCRIPTION
This PR adds members of [container-storage-interface-working-group](https://groups.google.com/forum/#!forum/container-storage-interface-working-group) to wg-storage and a link to the google group.