### PR TITLE
Update cncf/wg-storage page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,61 +4,19 @@ CNCF Storage Working Group
 
 ## Goals
 
-Explore cloud native storage technology and concepts around a container storage interface (CSI).
+Explore cloud native storage technology and concepts.
 
-See this [google doc](https://docs.google.com/document/d/1JMNVNP-ZHz8cGlnqckOnpJmHF-DNY7IYP-Di7iuVhQI/edit#) for more information
+## Initiatives and Projects
 
-## Members
+### Container Storage Interface (CSI)
 
-* Cloud Foundry
-  * Julian Hjortshoj ([@julian-hj](https://github.com/julian-hj))
-  * Paul Warren ([@paulcwarren](https://github.com/paulcwarren))
-* Dell EMC
-  * Clinton Kitson ([@clintonskitson](https://github.com/clintonskitson))
-  * Steve Wong ([@cantbewong](https://github.com/cantbewong))
-* Diamanti
-  * Chakravarthy Nelluri ([@chakri-nelluri](https://github.com/chakri-nelluri))
-* Docker
-  * Brian Goff ([@cpuguy83](https://github.com/cpuguy83))
-  * Julien Quintard ([@mycure](https://github.com/mycure))
-  * Mike Goelzer ([@mgoelzer](https://github.com/mgoelzer))
-* Google
-  * Saad Ali ([@saad-ali](https://github.com/saad-ali))
-  * Michael Rubin ([@matchstick](https://github.com/matchstick))
-  * Tim Hockin ([@thockin](https://github.com/thockin))
-* Huawei
-  * Steven Tan ([@stevenphtan](https://github.com/stevenphtan))
-* IBM
-  * Sandy Amin ([@sandyamin123](https://github.com/sandaymin123))
-  * Akash Gunjal ([@akgunjal](https://github.com/akgunjal))
-  * Mohamed Mohamed ([@midoblgsm](https://github.com/midoblgsm))
-  * Rakesh Jain ([@rakeshjn](https://github.com/rakeshjn))
-* iguazio
-  * Yaron Haviv ([@yaronhaviv](https://github.com/yaronha))
-  * Orit Nissan-Messing ([@oritnnm](https://github.com/oritnm))
-* Mesosphere
-  * Ben Hindman ([@benh](https://github.com/benh)) **[chair]**
-  * James DeFelice ([@jdef](https://github.com/jdef))
-  * Jie Yu ([@jieyu](https://github.com/jieyu))
-* Portworx
-  * Venkat Ramakrishnan ([@venkatpx](https://github.com/venkatpx))
-  * Gou Rao ([@gourao](https://github.com/gourao))
-  * Vinod Jayaraman ([@jvinod](https://github.com/jvinod))
-* Quantum (rook.io)
-  * Bassam Tabbara ([@bassam](https://github.com/bassam))
-* Red Hat
-  * Steve Watt ([@wattsteve](https://github.com/wattsteve))
-  * Adam Litke ([#@aglitke](https://github.com/aglitke))
-* StorageOS
-  * Alex Chircop ([@chira001](https://github.com/chira001))
-* Western Digital (SanDisk)
-  * Allen Samuels ([@allensamuels](https://github.com/allensamuels))
-* PURE Storage Inc
-  * Taher Vohra ([@taherv](https://github.com/taherv))
-  
-## Mailing List
+A project that aims to define an industry standard “container storage interface” (CSI). This interface would enable a storage vendors to write a driver once and have it work across a number of container orchestration (CO) systems
 
-https://groups.google.com/forum/#!forum/container-storage-interface-working-group
+See this [google doc](https://docs.google.com/document/d/1JMNVNP-ZHz8cGlnqckOnpJmHF-DNY7IYP-Di7iuVhQI/edit#) for more information.
+
+## Members and Mailing List
+
+https://groups.google.com/forum/#!forum/cncf-wg-storage
 
 ## Meeting Minutes
 


### PR DESCRIPTION
* Add link to new cncf-wg-storage Google group for centralized communication.
* Removed "list of members" to deemphasis "membership" (unreasonable to maintain a list here).
* Add a projects section and moved CSI into it (signifies that cncf/wg-storage is broader than just CSI).

CC @benh @clintonskitson