### PR TITLE
Corrects google group name to cncf-wg-storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ See this [google doc](https://docs.google.com/document/d/1JMNVNP-ZHz8cGlnqckOnpJ
   
 ## Mailing List
 
+https://groups.google.com/forum/#!forum/container-storage-interface-working-group
 https://groups.google.com/forum/#!forum/cncf-wg-storage
 
 ## Meeting Minutes

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ See this [google doc](https://docs.google.com/document/d/1JMNVNP-ZHz8cGlnqckOnpJ
   
 ## Mailing List
 
-https://groups.google.com/forum/#!forum/container-storage-interface-working-group
+https://groups.google.com/forum/#!forum/cncf-wg-storage
 
 ## Meeting Minutes
 


### PR DESCRIPTION
This PR adds the group link to the existing/accessible group "cncf-wg-storage".
