### PR TITLE
The project list was ordered and not alphabetical

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ The whitepaper is available here: http://bit.ly/cncf-storage-whitepaper
 
 ## Current CNCF Storage Projects
 
-1. TiKV
-2. etcd
-3. Vitess
-4. Rook
-5. OpenEBS
+- etcd
+- OpenEBS
+- Rook
+- TiKV
+- Vitess
 
 
 ## Operating Model


### PR DESCRIPTION
The sig-storage project list used an ordered list that did not comply with
markdown format. Instead of keeping the list in ordered format, I have
unordered the list, then sorted it alphabetically.