### PR TITLE
Add Longhorn into incubating project

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ PDF copy is availaber in the repo here: https://github.com/cncf/tag-storage/blob
 ### Incubating Projects
 
 - [Dragonfly](https://github.com/dragonflyoss/Dragonfly)
+- [Longhorn](https://github.com/longhorn/longhorn)
 
 ### Sandbox Projects
 
 - [ChubaoFS](https://github.com/chubaofs/chubaofs)
-- [Longhorn](https://github.com/longhorn/longhorn)
 - [OpenEBS](https://github.com/openebs)
 - [Pravega](https://github.com/pravega/pravega)
 - [Piraeus](https://github.com/piraeusdatastore/piraeus)


### PR DESCRIPTION
Longhorn has become a CNCF incubating project since Oct 2021.

https://www.cncf.io/projects/longhorn/

Signed-off-by: Sheng Yang <sheng@yasker.org>