### PR TITLE
ChubaoFS has changed its name to CubeFS. CubeFS and Longhorn has ente…

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ PDF copy is availaber in the repo here: https://github.com/cncf/tag-storage/blob
 ### Incubating Projects
 
 - [Dragonfly](https://github.com/dragonflyoss/Dragonfly)
+- [CubeFS](https://github.com/cubeFS/cubefs)
+- [Longhorn](https://github.com/longhorn/longhorn)
 
 ### Sandbox Projects
 
-- [ChubaoFS](https://github.com/chubaofs/chubaofs)
-- [Longhorn](https://github.com/longhorn/longhorn)
 - [OpenEBS](https://github.com/openebs)
 - [Pravega](https://github.com/pravega/pravega)
 - [Piraeus](https://github.com/piraeusdatastore/piraeus)

--- a/storage-charter.md
+++ b/storage-charter.md
@@ -70,9 +70,10 @@ cloud-native environments through:
 # Current CNCF Storage Projects
 
 - [etcd](https://github.com/etcd-io/etcd)
-- [ChubaoFS](https://github.com/chubaofs/chubaofs)
+- [CubeFS](https://github.com/cubeFS/cubefs)
 - [Longhorn](https://github.com/longhorn/longhorn)
 - [OpenEBS](https://github.com/openebs)
+- [Piraeus](https://github.com/piraeusdatastore/piraeus)
 - [Rook](https://github.com/rook/rook)
 - [TiKV](https://github.com/tikv/tikv)
 - [Vitess](https://github.com/vitessio/vitess)


### PR DESCRIPTION
…red incubating stage.

Signed-off-by: alexzhc <alex.zheng@daocloud.io>

Hi @chira001 

I've updated README as:

1. ChubaoFS has changed its name to CubeFS;
2. Both CubeFS and Longhorn have entered incubating stage.

Regards