### PR TITLE
Clean-up: Update settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -11,29 +11,5 @@ repository:
   homepage: https://cncf.io
   
   # Collaborators: give specific users access to this repository.
-collaborators:
-  - username: chira001
-    # Note: Only valid on organization-owned repositories.
-    # The permission to grant the collaborator. Can be one of:
-    # * `pull` - can pull, but not push to or administer this repository.
-    # * `push` - can pull and push, but not administer this repository.
-    # * `admin` - can pull, push and administer this repository.
-    permission: admin
-
-  - username: sougou
-    permission: admin
-    
-  - username: quinton-hoole
-    permission: admin
-    
-  - username: erinboyd
-    permission: admin
-
-  - username: xing-yang
-    permission: admin
-
-  - username: saad-ali
-    permission: admin
-
-  - username: lpabon
-    permission: admin
+  # Note that the permissions are controlled using CLOWarden in the https://github.com/cncf/people/blob/main/config.yaml file
+  # Please create a PR in the https://github.com/cncf/people/ repo to change user access


### PR DESCRIPTION
People and permissions have been moved to the [cncf/people/config.yml file](https://github.com/cncf/people/blob/main/config.yaml) making permissions in the local settings.yml file redundant.

Proposed updates:

- [x]  Remove the people from the local settings.yml
- [x]  Add a link in the setting.yml to the [cncf/people/config.yml file](https://github.com/cncf/people/blob/main/config.yaml#L898) for clarity