### PR TITLE
Fix broken link to cncf operating model in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The document is available [here](data-on-kubernetes-whitepaper/data-on-kubernete
 ## Operating Model
 
 This TAG follows the [standard operating
-guidelines](https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md#operating-model)
+guidelines](https://github.com/cncf/toc/blob/main/tags/README.md#operating-model)
 provided by the TOC unless otherwise stated here.
 
 **Current TOC Liaison:** Nikhita Raghunath, Matt Farina


### PR DESCRIPTION
The link to the Operational Model in the README points to a file that does not exists anymore after many refactoring in the [cncf/toc Github project](https://github.com/cncf/toc).

The file has initially been renamed in this PR: https://github.com/cncf/toc/pull/658/commits
Moreover, that repository has been restructured, moving the content in different files inside the `tags` directory: https://github.com/cncf/toc/blob/main/tags

This PR fixes the broken link, restoring it to point to the right paragraph in the right file.